### PR TITLE
chore: move to specific imports

### DIFF
--- a/mkdocs_nav_weight/__init__.py
+++ b/mkdocs_nav_weight/__init__.py
@@ -1,16 +1,19 @@
 from numbers import Number
-import mkdocs
+
+from mkdocs.config import config_options
+from mkdocs.plugins import BasePlugin
+
 from mkdocs_nav_weight.util import Util
 
 
-class MkDocsNavWeight(mkdocs.plugins.BasePlugin):
+class MkDocsNavWeight(BasePlugin):
 
     config_scheme = (
-        ('section_renamed', mkdocs.config.config_options.Type(bool, default=False)),
-        ('index_weight', mkdocs.config.config_options.Type(Number, default=-10)),
-        ('warning', mkdocs.config.config_options.Type(bool, default=True)),
-        ('reverse', mkdocs.config.config_options.Type(bool, default=False)),
-        ('headless_included', mkdocs.config.config_options.Type(bool, default=False)),
+        ('section_renamed', config_options.Type(bool, default=False)),
+        ('index_weight', config_options.Type(Number, default=-10)),
+        ('warning', config_options.Type(bool, default=True)),
+        ('reverse', config_options.Type(bool, default=False)),
+        ('headless_included', config_options.Type(bool, default=False)),
     )
 
     def on_nav(self, nav, config, files, **kwargs):


### PR DESCRIPTION
Hey,

first of all thanks for the plugin! It's awesome!

We had some trouble to install it with the nix-Package manager. It builds the plugin with the `setup.py`, but crashes with the following error.

```
       last 10 log lines:
       >     return _bootstrap._gcd_import(name[level:], package, level)
       >   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
       >   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
       >   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
       >   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
       >   File "/nix/store/vd9vncpxblh3l6j29mzqvrgl75blmbhy-python3.10-mkdocs-nav-weight-0.0.9/lib/python3.10/site-packages/mkdocs_nav_weight/__init__.py", line 6, in <module>
       >     class MkDocsNavWeight(mkdocs.plugins.BasePlugin):
       > AttributeError: module 'mkdocs' has no attribute 'plugins'
```

This occures because the plugin imports the `mkdocs` plugin and tries to use it as an object.

This pull request directly imports required parameters, such that the error is fixed.

Feel free to ask any questions. :) 