### PR TITLE
Fixed typo/misspelling in warning message

### DIFF
--- a/mkdocs_nav_weight/nav_setter.py
+++ b/mkdocs_nav_weight/nav_setter.py
@@ -66,7 +66,7 @@ class NavSetter():
             # option: "warning"
             elif self.is_warning:
                 log.warning(
-                    f"[mkdocs-nav-weight]: Invaild value for \"{key}\" in {page}, setting to \"{result}\"")
+                    f"[mkdocs-nav-weight]: Invalid value for \"{key}\" in {page}, setting to \"{result}\"")
 
         return result
 


### PR DESCRIPTION
Line 69 had a type/misspelling.  Was "Invaild".  Fixed to "Invalid"

Would it also be necessary to bump the version to 0.2.1 or something like that in setup.py?